### PR TITLE
PLIN-2610: Update Module Path

### DIFF
--- a/api_tests/marshal_json_test.go
+++ b/api_tests/marshal_json_test.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"github.com/json-iterator/go"
-	"testing"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
-
 
 type Foo struct {
 	Bar interface{}
@@ -19,11 +18,10 @@ func (f Foo) MarshalJSON() ([]byte, error) {
 	return buf.Bytes(), err
 }
 
-
 // Standard Encoder has trailing newline.
 func TestEncodeMarshalJSON(t *testing.T) {
 
-	foo := Foo {
+	foo := Foo{
 		Bar: 123,
 	}
 	should := require.New(t)

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
-module github.com/json-iterator/go
+module github.com/skuid/json-iterator-go
 
 go 1.12
 
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/gofuzz v1.0.0
+	github.com/json-iterator/go v1.1.10
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
+github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=

--- a/reflect.go
+++ b/reflect.go
@@ -30,6 +30,11 @@ type ValEncoder interface {
 	Encode(ptr unsafe.Pointer, stream *Stream)
 }
 
+// MapKeySorter is used to define a custom function for sorting the keys of maps
+type MapKeySorter interface {
+	Sort(keyA string, keyB string) bool
+}
+
 type checkIsEmpty interface {
 	IsEmpty(ptr unsafe.Pointer) bool
 }

--- a/reflect_extension.go
+++ b/reflect_extension.go
@@ -49,6 +49,7 @@ type Extension interface {
 	UpdateStructDescriptor(structDescriptor *StructDescriptor)
 	CreateMapKeyDecoder(typ reflect2.Type) ValDecoder
 	CreateMapKeyEncoder(typ reflect2.Type) ValEncoder
+	CreateMapKeySorter() MapKeySorter
 	CreateDecoder(typ reflect2.Type) ValDecoder
 	CreateEncoder(typ reflect2.Type) ValEncoder
 	DecorateDecoder(typ reflect2.Type, decoder ValDecoder) ValDecoder
@@ -70,6 +71,11 @@ func (extension *DummyExtension) CreateMapKeyDecoder(typ reflect2.Type) ValDecod
 
 // CreateMapKeyEncoder No-op
 func (extension *DummyExtension) CreateMapKeyEncoder(typ reflect2.Type) ValEncoder {
+	return nil
+}
+
+// CreateMapKeySorter No-op
+func (extension *DummyExtension) CreateMapKeySorter() MapKeySorter {
 	return nil
 }
 
@@ -119,6 +125,11 @@ func (extension EncoderExtension) CreateMapKeyEncoder(typ reflect2.Type) ValEnco
 	return nil
 }
 
+// CreateMapKeySorter No-op
+func (extension EncoderExtension) CreateMapKeySorter() MapKeySorter {
+	return nil
+}
+
 // DecorateDecoder No-op
 func (extension EncoderExtension) DecorateDecoder(typ reflect2.Type, decoder ValDecoder) ValDecoder {
 	return decoder
@@ -142,6 +153,11 @@ func (extension DecoderExtension) CreateMapKeyDecoder(typ reflect2.Type) ValDeco
 
 // CreateMapKeyEncoder No-op
 func (extension DecoderExtension) CreateMapKeyEncoder(typ reflect2.Type) ValEncoder {
+	return nil
+}
+
+// CreateMapKeySorter No-op
+func (extension DecoderExtension) CreateMapKeySorter() MapKeySorter {
 	return nil
 }
 

--- a/reflect_map.go
+++ b/reflect_map.go
@@ -28,6 +28,7 @@ func encoderOfMap(ctx *ctx, typ reflect2.Type) ValEncoder {
 		return &sortKeysMapEncoder{
 			mapType:     mapType,
 			keyEncoder:  encoderOfMapKey(ctx.append("[mapKey]"), mapType.Key()),
+			keySorter:   sorterOfMapKey(ctx),
 			elemEncoder: encoderOfType(ctx.append("[mapElem]"), mapType.Elem()),
 		}
 	}
@@ -36,6 +37,23 @@ func encoderOfMap(ctx *ctx, typ reflect2.Type) ValEncoder {
 		keyEncoder:  encoderOfMapKey(ctx.append("[mapKey]"), mapType.Key()),
 		elemEncoder: encoderOfType(ctx.append("[mapElem]"), mapType.Elem()),
 	}
+}
+
+type defaultMapKeySorter struct {
+}
+
+func (sorter defaultMapKeySorter) Sort(keyA string, keyB string) bool {
+	return keyA < keyB
+}
+
+func sorterOfMapKey(ctx *ctx) MapKeySorter {
+	for _, extension := range ctx.extraExtensions {
+		sorter := extension.CreateMapKeySorter()
+		if sorter != nil {
+			return sorter
+		}
+	}
+	return defaultMapKeySorter{}
 }
 
 func decoderOfMapKey(ctx *ctx, typ reflect2.Type) ValDecoder {
@@ -275,6 +293,7 @@ func (encoder *mapEncoder) IsEmpty(ptr unsafe.Pointer) bool {
 type sortKeysMapEncoder struct {
 	mapType     *reflect2.UnsafeMapType
 	keyEncoder  ValEncoder
+	keySorter   MapKeySorter
 	elemEncoder ValEncoder
 }
 
@@ -287,7 +306,7 @@ func (encoder *sortKeysMapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 	mapIter := encoder.mapType.UnsafeIterate(ptr)
 	subStream := stream.cfg.BorrowStream(nil)
 	subIter := stream.cfg.BorrowIterator(nil)
-	keyValues := encodedKeyValues{}
+	keyValues := []encodedKV{}
 	for mapIter.HasNext() {
 		subStream.buf = make([]byte, 0, 64)
 		key, elem := mapIter.UnsafeNext()
@@ -309,7 +328,11 @@ func (encoder *sortKeysMapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 			keyValue: subStream.Buffer(),
 		})
 	}
-	sort.Sort(keyValues)
+	keyValueWrapper := encodedKeyValues{
+		keySorter: encoder.keySorter,
+		values:    keyValues,
+	}
+	sort.Sort(keyValueWrapper)
 	for i, keyValue := range keyValues {
 		if i != 0 {
 			stream.WriteMore()
@@ -326,13 +349,18 @@ func (encoder *sortKeysMapEncoder) IsEmpty(ptr unsafe.Pointer) bool {
 	return !iter.HasNext()
 }
 
-type encodedKeyValues []encodedKV
+type encodedKeyValues struct {
+	keySorter MapKeySorter
+	values    []encodedKV
+}
 
 type encodedKV struct {
 	key      string
 	keyValue []byte
 }
 
-func (sv encodedKeyValues) Len() int           { return len(sv) }
-func (sv encodedKeyValues) Swap(i, j int)      { sv[i], sv[j] = sv[j], sv[i] }
-func (sv encodedKeyValues) Less(i, j int) bool { return sv[i].key < sv[j].key }
+func (sv encodedKeyValues) Len() int      { return len(sv.values) }
+func (sv encodedKeyValues) Swap(i, j int) { sv.values[i], sv.values[j] = sv.values[j], sv.values[i] }
+func (sv encodedKeyValues) Less(i, j int) bool {
+	return sv.keySorter.Sort(sv.values[i].key, sv.values[j].key)
+}


### PR DESCRIPTION
When upgrading skuid-cli to use the Go module system the following error was encountered:

```shell
~/go/src/github.com/skuid/skuid-cli PLIN-2334-Upgrade-to-Go-1.14* ⇡
❯ go get
go: github.com/skuid/json-iterator-go@v1.1.7: parsing go.mod:
	module declares its path as: github.com/json-iterator/go
	        but was required as: github.com/skuid/json-iterator-go
```

The module declaration in our fork needs to be updated to github.com/skuid/json-iterator-go.